### PR TITLE
test: add testing for database and flask application

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,11 @@ from playhouse.shortcuts import model_to_dict
 load_dotenv()
 app = Flask(__name__)
 
-mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"), user=os.getenv("MYSQL_USER"), password=os.getenv("MYSQL_PASSWORD"), host=os.getenv("MYSQL_HOST"), port=3306)
+mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
+    user=os.getenv("MYSQL_USER"),
+    password=os.getenv("MYSQL_PASSWORD"),
+    host=os.getenv("MYSQL_HOST"),
+    port=3306)
 
 class TimelinePost(Model):
     name = CharField()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,11 +10,15 @@ from playhouse.shortcuts import model_to_dict
 load_dotenv()
 app = Flask(__name__)
 
-mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
-    user=os.getenv("MYSQL_USER"),
-    password=os.getenv("MYSQL_PASSWORD"),
-    host=os.getenv("MYSQL_HOST"),
-    port=3306)
+if os.getenv("TESTING") == "true":
+    print("Running in test mode")
+    mydb = SqliteDatabase("file:memory?mode=memory&cache=shared", uri=True)
+else:
+    mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
+        user=os.getenv("MYSQL_USER"),
+        password=os.getenv("MYSQL_PASSWORD"),
+        host=os.getenv("MYSQL_HOST"),
+        port=3306)
 
 class TimelinePost(Model):
     name = CharField()

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PWD/env/bin/python -m unittest discover -v tests/
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,57 @@
+# tests/test_app.py
+
+import unittest
+import os
+os.environ['TESTING'] = 'true'
+
+from app import app
+
+class AppTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+
+    def test_home(self):
+        response = self.client.get("/")
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert "<title>MLH Fellow</title>" in html
+        assert "1"
+        assert "<strong>About Me!</strong>" in html
+        assert "<strong>backlight-simulator</strong>" in html
+        # TODO Add more tests relating to the home page
+
+    def test_timeline(self):
+        post_response = self.client.get("/api/timeline_post")
+        assert post_response.status_code == 200
+        assert post_response.is_json
+        post_json = post_response.get_json()
+
+        print("GET: ", post_json)
+
+        # if json is null, then we should throw False assertion
+        if not post_json:
+            assert False, "No post_json?"
+
+        assert "timeline_posts" in post_json
+        # assert len(json["timeline_posts"]) == 0
+
+        get_response = self.client.get("/api/timeline_post")
+        assert get_response.status_code == 200
+        assert get_response.is_json
+        get_json = get_response.get_json()
+
+        print("GET: ", get_json)
+
+        # if json is null, then we should throw False assertion
+        if not get_json:
+            assert False, "No get_json?"
+
+        assert "timeline_posts" in get_json
+        
+        response = self.client.get("/timeline")
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert "<h2>Timeline Posts</h2>" in html
+        assert "<h2>Timeline Posts</h2>" in html
+        assert "<h2>Leave a Timeline Post</h2>" in html
+        

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,52 @@
+import unittest
+from peewee import *
+from playhouse.shortcuts import model_to_dict
+from app import TimelinePost
+
+MODELS = [TimelinePost]
+
+# Use an in-memory SQLite for tests.
+test_db = SqliteDatabase(':memory:')
+
+class TestTimelinePost(unittest.TestCase):
+    def setUp(self):
+        # Bind model classes to test db. Since we have a complete list of
+        # all models, we do not need to recursively bind dependencies.
+        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+
+        test_db.connect()
+        test_db.create_tables(MODELS)
+
+    def tearDown(self):
+        # Not strictly necessary since SQLite in-memory databases only live
+        # for the duration of the connection, and in the next step we close
+        # the connection... but a good practice all the same.
+        test_db.drop_tables(MODELS)
+
+        # Close connection to db.
+        test_db.close()
+
+    def test_timeline_post(self):
+        # Create 2 timeline posts.
+        first_post = TimelinePost.create(name='John Doe',
+            email='john@example.com', content='Hello world, I\'m John!')
+        assert first_post.id == 1
+
+        second_post = TimelinePost.create(name='Jane Doe',
+            email='jane@example.com', content='Hello world, I\'m Jane!')
+        assert second_post.id == 2
+
+    # TODO: Get timeline posts and assert that they ar
+    def test_timeline_get(self):
+        first_post = TimelinePost.create(name='John Doe',
+            email='john@example.com', content='Hello world, I\'m John!')
+
+        second_post = TimelinePost.create(name='Jane Doe',
+            email='jane@example.com', content='Hello world, I\'m Jane!')
+
+        posts = [model_to_dict(p) for p in TimelinePost.select().order_by(TimelinePost.created_at.desc())]
+
+        # the posts[1] correlates to the the id of 1 because it was created earlier, its at the bottom of the stack
+        assert posts[1]["id"] == 1
+        assert posts[0]["id"] == 2
+


### PR DESCRIPTION
Resolves #20 and #19 

### **Description**
This PR aims to add unit testing to the `MySQL` database, ensuring that the `Peewee` ORM operates and results in an expected value of the correct schema.

This PR also aims to add integration testing to `Flask` application, where we assert whether or not `GET` and `POST` API requests are functioning properly and whether or not some HTML elements exist.

### **Reproduce**
1. run `git clone https://github.com/michaelwong3049/pe-portfolio-website`
2. `cd` into the project
3. create a python virtual environment and run `pip install -r requirements.txt`
4. run `source your_venv/bin/activate` to activate the virtual environment

To run the tests for the databases in `/tests/test_db.py`
run `python -m unittest -v tests.test_db`  

To run the tests for the databases in `/tests/test__app.py`
run `python -m unittest -v tests.test_app`